### PR TITLE
refactor: replace the `amazon-cognito-identity-js` lib use in the signup.js

### DIFF
--- a/attr-based-access-ctrl/frontend/README.md
+++ b/attr-based-access-ctrl/frontend/README.md
@@ -190,12 +190,11 @@ npm run refresh-session userType=<free | premium>
   to sign requests with AWS Signature Version 4. The `/membership` endpoint is secured by IAM authorization,
   so only authenticated users can invoke it.
 
-- The `amazon-cognito-identity-js` package is used to communicate with the user pool and identity pool to
-  handle the sign-up, sign-in, token refresh, etc.
+- The `amazon-cognito-identity-js` package is used to communicate with the user pool to
+  handle the sign-in.
 
 ## Improvements
 
 - Replace the `amazon-cognito-identity-js` package with the compatible V3 version of the AWS SDK.
   - To communicate with the Cognito User Pool - [client-cognito-identity-provider](https://www.npmjs.com/package/@aws-sdk/client-cognito-identity-provider)
-  - To communicate with the Cognito Identity Pool - [client-cognito-identity](https://www.npmjs.com/package/@aws-sdk/client-cognito-identity)
 - Update the sign-up flow to use PKCE (Proof Key for Code Exchange).

--- a/attr-based-access-ctrl/frontend/src/signin.js
+++ b/attr-based-access-ctrl/frontend/src/signin.js
@@ -21,6 +21,9 @@ const sessionUser = usersConfig[userType];
 
 await signIn();
 
+// Logs the user into the application
+// The UserPool client is configured to support only Secure Remote Password (SRP) authentication flow for enhanced security
+//  and the `amazon-cognito-identity-js` lib handles this part internally
 async function signIn() {
   const userPoolConfig = getUserPoolConfig();
   const userPool = new CognitoUserPool(userPoolConfig);


### PR DESCRIPTION
Updated the signup.js to replace the amazon-cognito-identity-js lib usage with the @aws-sdk/client-cognito-identity-provider.